### PR TITLE
Chore/dangerous func native reward

### DIFF
--- a/contracts/soulbounds/RewardsNative.sol
+++ b/contracts/soulbounds/RewardsNative.sol
@@ -147,9 +147,24 @@ contract RewardsNative is
         return _decodeData(_data);
     }
 
-    function createTokenAndDepositRewards(
+    function _dangerous_createTokenAndDepositRewards(
         LibRewards.RewardToken calldata _token
     ) public payable onlyRole(DEV_CONFIG_ROLE) {
+        _createTokenAndDepositRewards(_token);
+    }
+
+    function createMultipleTokensAndDepositRewards(
+        LibRewards.RewardToken[] calldata _tokens
+    ) external payable onlyRole(DEV_CONFIG_ROLE) {
+        // Create tokens and deposit rewards
+        for (uint256 i = 0; i < _tokens.length; i++) {
+            _createTokenAndDepositRewards(_tokens[i]);
+        }
+    }
+
+    function createTokenAndDepositRewards(
+        LibRewards.RewardToken calldata _token
+    ) public payable onlyRole(MANAGER_ROLE) {
         uint256 _ethRequired = _calculateETHRequiredForToken(_token);
 
         if (msg.value < _ethRequired) {
@@ -161,7 +176,7 @@ contract RewardsNative is
 
     function createMultipleTokensAndDepositRewards(
         LibRewards.RewardToken[] calldata _tokens
-    ) external payable onlyRole(DEV_CONFIG_ROLE) {
+    ) external payable onlyRole(MANAGER_ROLE) {
         uint256 totalETHRequired;
 
         // Calculate the total ETH required for all tokens

--- a/contracts/soulbounds/RewardsNative.sol
+++ b/contracts/soulbounds/RewardsNative.sol
@@ -153,7 +153,7 @@ contract RewardsNative is
         _createTokenAndDepositRewards(_token);
     }
 
-    function createMultipleTokensAndDepositRewards(
+    function _dangerous_createMultipleTokensAndDepositRewards(
         LibRewards.RewardToken[] calldata _tokens
     ) external payable onlyRole(DEV_CONFIG_ROLE) {
         // Create tokens and deposit rewards


### PR DESCRIPTION
This pull request introduces several changes to the `RewardsNative` contract and its associated tests to refine role-based access control and add new functionalities. The most important changes include the addition of new functions for creating and depositing rewards, and modifications to the tests to align with the updated role requirements.

### Contract Changes:
* Added `_dangerous_createTokenAndDepositRewards` and `_dangerous_createMultipleTokensAndDepositRewards` functions to handle token creation and reward deposits with `DEV_CONFIG_ROLE` access. (`contracts/soulbounds/RewardsNative.sol`)
* Changed `createMultipleTokensAndDepositRewards` to be accessible by `MANAGER_ROLE` instead of `DEV_CONFIG_ROLE`. (`contracts/soulbounds/RewardsNative.sol`)

### Test Changes:
* Updated test fixtures to include `managerWallet` and modified tests to use `managerWallet` instead of `devWallet` for creating and depositing rewards. (`test/hardhatTests/rewardsNative.test.ts`) [[1]](diffhunk://#diff-29145b7ab868020bba332826d354023c5073f76c49ff61db5397edf963077012L73-R73) [[2]](diffhunk://#diff-29145b7ab868020bba332826d354023c5073f76c49ff61db5397edf963077012R82-R84) [[3]](diffhunk://#diff-29145b7ab868020bba332826d354023c5073f76c49ff61db5397edf963077012L96-R97) [[4]](diffhunk://#diff-29145b7ab868020bba332826d354023c5073f76c49ff61db5397edf963077012L105-R120) [[5]](diffhunk://#diff-29145b7ab868020bba332826d354023c5073f76c49ff61db5397edf963077012R130-R132) [[6]](diffhunk://#diff-29145b7ab868020bba332826d354023c5073f76c49ff61db5397edf963077012L142-R146) [[7]](diffhunk://#diff-29145b7ab868020bba332826d354023c5073f76c49ff61db5397edf963077012R156-R160) [[8]](diffhunk://#diff-29145b7ab868020bba332826d354023c5073f76c49ff61db5397edf963077012R192-R194) [[9]](diffhunk://#diff-29145b7ab868020bba332826d354023c5073f76c49ff61db5397edf963077012L258-R266) [[10]](diffhunk://#diff-29145b7ab868020bba332826d354023c5073f76c49ff61db5397edf963077012L327-R335) [[11]](diffhunk://#diff-29145b7ab868020bba332826d354023c5073f76c49ff61db5397edf963077012L357-R365)
