### PR TITLE
Feat: Add setToken function to GUnits

### DIFF
--- a/contracts/upgradeables/games/GUnits.sol
+++ b/contracts/upgradeables/games/GUnits.sol
@@ -8,9 +8,6 @@ import {
     IERC20
 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {
-    IERC20Metadata
-} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
-import {
     AccessControlUpgradeable
 } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import {
@@ -109,6 +106,7 @@ contract GUnits is
         uint256 amount,
         bool returned
     );
+    event TokenSet(address indexed newToken);
     error ChipInsufficientBalance(
         address from,
         uint256 fromBalance,
@@ -411,6 +409,16 @@ contract GUnits is
         numeratorExchangeRate = _numerator;
         denominatorExchangeRate = _denominator;
         emit ExchangeRateSet(_numerator, _denominator);
+    }
+
+    // @dev Sets the token
+    // @param _token The address of the token to set
+    function setToken(address _token) external onlyRole(DEV_CONFIG_ROLE) {
+        if (_token == address(0)) {
+            revert AddressIsZero();
+        }
+        token = _token;
+        emit TokenSet(_token);
     }
 
     // @dev Returns the exchange rate


### PR DESCRIPTION
Issue: resolves https://linear.app/game7/issue/G7-83/function-to-change-token-currency

# 🐵 Description

This pull request introduces a new feature to the `GUnits` contract, allowing the token address to be set dynamically, along with corresponding updates to the test suite. Key changes include the addition of a `setToken` function, a new `TokenSet` event, and tests to validate the behavior of the new functionality.

### Changes to `GUnits` contract:

* Removed the import of `IERC20Metadata` from `@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol`, as it is no longer needed.
* Added a new `TokenSet` event to emit changes to the token address.
* Introduced a `setToken` function to allow updating the token address. The function includes validation to prevent setting the address to zero and emits the `TokenSet` event upon successful execution. It is restricted to accounts with the `DEV_CONFIG_ROLE`.

### Changes to `GUnits` test suite:

* Added a new test suite for the `setToken` function:
  - Validates that the token address can be updated and emits the `TokenSet` event.
  - Ensures the function reverts with a custom error when attempting to set the token address to zero.
  - Ensures the function reverts with a custom error when called by an account lacking the `DEV_CONFIG_ROLE`.

