### PR TITLE
Fix: Fix wrong balance check of amounts to lock the funds

### DIFF
--- a/contracts/upgradeables/games/GUnits.sol
+++ b/contracts/upgradeables/games/GUnits.sol
@@ -602,11 +602,9 @@ contract GUnits is
         if (amount == 0) revert InvalidAmount();
 
         uint256 userBalance = balances[user];
-        uint256 totalLocked = lockedFunds[user];
-        uint256 availableBalance = userBalance - totalLocked;
 
-        if (availableBalance < amount) {
-            revert InsufficientUnlockedBalance(user, amount, availableBalance);
+        if (userBalance < amount) {
+            revert InsufficientUnlockedBalance(user, amount, userBalance);
         }
 
         lockedFunds[user] += amount;


### PR DESCRIPTION
This pull request makes a critical adjustment to the balance validation logic in the `GUnits` contract to simplify and correct the calculation of available funds for a user.

### Changes to balance validation:

* [`contracts/upgradeables/games/GUnits.sol`](diffhunk://#diff-23ef7fab2ff47ca3e5a0688c510a942be09ef643c3c6516fb490d1b49c5671faL605-R607): Removed the calculation of `totalLocked` and `availableBalance`. The validation now directly checks if `userBalance` is less than the `amount`, simplifying the logic and ensuring correctness.