### PR TITLE
Fix/fix extra buy in

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,20 @@ pnpm deploy:g7:testnet --name Forwarder
 ```
 
 You need to provide the **name** argument with the contract name you want to deploy.
+
+## Upgrades
+
+How to upgrade an upgradeable contract with our custom task:
+
+```shell
+pnpm run upgrade:arbitrum:sepolia --name GUnits --contractversion 2
+```
+
+## Verifications
+
+How to verify a custom interface:
+example:
+
+```shell
+pnpm hardhat --config arbitrum.config.ts verify --network arbitrumSepolia 0x9A984C46177cf900028e31c0355f541B804e3828
+```

--- a/constants/network.ts
+++ b/constants/network.ts
@@ -2,7 +2,7 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-const { INFURA_API_KEY } = process.env;
+const { INFURA_API_KEY, ALCHEMY_API_KEY } = process.env;
 
 export enum NETWORK_TYPE {
     MAINNET = 'MAINNET',
@@ -136,8 +136,8 @@ export const rpcUrls = {
     [ChainId.PolygonMumbai]: 'https://rpc.ankr.com/polygon_mumbai',
     [ChainId.Mantle]: 'https://rpc.mantle.xyz',
     [ChainId.MantleSepolia]: 'https://rpc.sepolia.mantle.xyz',
-    [ChainId.ArbitrumOne]: 'https://arb1.arbitrum.io/rpc',
-    [ChainId.ArbitrumSepolia]: 'https://sepolia-rollup.arbitrum.io/rpc',
+    [ChainId.ArbitrumOne]: `https://arb-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}`,
+    [ChainId.ArbitrumSepolia]: `https://arb-sepolia.g.alchemy.com/v2/${ALCHEMY_API_KEY}`,
     [ChainId.OPMainnet]: 'https://mainnet.optimism.io',
     [ChainId.OPSepolia]: 'https://sepolia.optimism.io',
     [ChainId.Base]: 'https://mainnet.base.org',

--- a/constants/upgrades/index.ts
+++ b/constants/upgrades/index.ts
@@ -31,6 +31,21 @@ export const CONTRACTS: DeploymentContract[] = [
         dependencies: [],
         functionCalls: [],
     },
+    {
+        name: 'GUnits', // Logical name used in the --name parameter of the upgrade task
+        contractFileName: 'GUnits', // The .sol file name of the NEW GUnits implementation (e.g., GUnitsV2 if different)
+        type: CONTRACT_TYPE.GUnits, // Replace with your actual CONTRACT_TYPE if available and applicable
+        chain: NetworkName.ArbitrumOne, // << UPDATE THIS: e.g., 'arbitrumSepolia', 'mainnet', 'sepolia'
+        networkType: NETWORK_TYPE.MAINNET, // << UPDATE THIS: Your NETWORK_TYPE if applicable
+        version: 2, // << UPDATE THIS: The NEW version number this configuration represents
+        tenants: [TENANT.Game7], // << UPDATE THIS: Array of applicable TENANTs. Cast as any if TENANT is a complex type not imported.
+        upgradable: true,
+        proxyAddress: '0xd5613B0B45baad0547fA70A9d65A91622e776B11', // << From your example
+        verify: true,
+        args: {},
+        dependencies: [],
+        functionCalls: [],
+    },
     // Add configurations for other contracts or other versions you might want to upgrade
 ];
 

--- a/constants/upgrades/index.ts
+++ b/constants/upgrades/index.ts
@@ -2,7 +2,10 @@
 
 // export const CONTRACTS = [...ZKSYNC_SEPOLIA_CONTRACTS];
 
+import { CONTRACT_TYPE } from '@constants/contract';
+import { TENANT } from '@constants/tenant';
 import { DeploymentContract } from '../../types/deployment-type'; // Adjust path if your types are elsewhere
+import { NETWORK_TYPE, NetworkName } from '../network';
 
 /**
  * IMPORTANT:
@@ -16,27 +19,17 @@ export const CONTRACTS: DeploymentContract[] = [
     {
         name: 'GUnits', // Logical name used in the --name parameter of the upgrade task
         contractFileName: 'GUnits', // The .sol file name of the NEW GUnits implementation (e.g., GUnitsV2 if different)
-        type: 'GameUnits' as any, // Replace with your actual CONTRACT_TYPE if available and applicable
-        chain: 'arbitrumSepolia', // << UPDATE THIS: e.g., 'arbitrumSepolia', 'mainnet', 'sepolia'
-        networkType: 'L2' as any, // << UPDATE THIS: Your NETWORK_TYPE if applicable
+        type: CONTRACT_TYPE.GUnits, // Replace with your actual CONTRACT_TYPE if available and applicable
+        chain: NetworkName.ArbitrumSepolia, // << UPDATE THIS: e.g., 'arbitrumSepolia', 'mainnet', 'sepolia'
+        networkType: NETWORK_TYPE.TESTNET, // << UPDATE THIS: Your NETWORK_TYPE if applicable
         version: 2, // << UPDATE THIS: The NEW version number this configuration represents
-        tenants: ['achievo' as any], // << UPDATE THIS: Array of applicable TENANTs. Cast as any if TENANT is a complex type not imported.
+        tenants: [TENANT.Game7], // << UPDATE THIS: Array of applicable TENANTs. Cast as any if TENANT is a complex type not imported.
         upgradable: true,
         proxyAddress: '0x3E95CB707F2274e91Cd643f445128818304eD4B5', // << From your example
         verify: true,
-        args: {
-            // Example: If your new GUnitsV2#initialize function (or reinitializer) takes arguments:
-            // initialOwner: "DEPLOYER_WALLET",
-            // someValue: 123,
-        },
+        args: {},
         dependencies: [],
-        // functionCalls: [
-        //   {
-        //     contractName: "GUnits", // Should match `name` or refer to the contract being called
-        //     functionName: "newFunctionInV2",
-        //     args: ["someArgForNewFunction"],
-        //   },
-        // ],
+        functionCalls: [],
     },
     // Add configurations for other contracts or other versions you might want to upgrade
 ];

--- a/contracts/upgradeables/games/GUnits.sol
+++ b/contracts/upgradeables/games/GUnits.sol
@@ -353,10 +353,7 @@ contract GUnits is
             emit FundsReleased(currentPayout.player, currentPayout.buyInAmount);
 
             if (currentPayout.isWinner) {
-                _mintGUnits(
-                    currentPayout.player,
-                    currentPayout.amount + currentPayout.buyInAmount
-                );
+                _mintGUnits(currentPayout.player, currentPayout.amount);
             }
         }
 

--- a/contracts/upgradeables/games/GUnits.sol
+++ b/contracts/upgradeables/games/GUnits.sol
@@ -131,11 +131,12 @@ contract GUnits is
     uint256 public denominatorExchangeRate;
 
     uint256 private collectedFees;
-    uint256 public decimals;
 
     // Locked funds tracking
     // user => total locked amount
     mapping(address => uint256) private lockedFunds;
+
+    uint256 public decimals;
 
     // @dev Initializes the contract
     // @param _token The address of the token to use for the g-units

--- a/test/gunits.lock.test.ts
+++ b/test/gunits.lock.test.ts
@@ -305,10 +305,11 @@ describe('GUnits-2', function () {
             } = await loadFixture(deployFixtures);
             const depositAmount = ethers.parseUnits('20', 6);
             const lockAmount = ethers.parseUnits('10', 6);
-            const firstPlaceAmount = ethers.parseUnits('43.2', 6);
-            const secondPlaceAmount = ethers.parseUnits('21.6', 6);
-            const thirdPlaceAmount = ethers.parseUnits('14.4', 6);
-            const fourthPlaceAmount = ethers.parseUnits('10.80', 6);
+            // Winners get payout minted on top of their 10 liquid balance
+            const firstPlaceAmount = ethers.parseUnits('43.2', 6); // 10 + 43.2 = 53.2 total
+            const secondPlaceAmount = ethers.parseUnits('21.6', 6); // 10 + 21.6 = 31.6 total
+            const thirdPlaceAmount = ethers.parseUnits('14.4', 6); // 10 + 14.4 = 24.4 total
+            const fourthPlaceAmount = ethers.parseUnits('10.80', 6); // 10 + 10.8 = 20.8 total
 
             // Setup initial balances
             await depositGUnitsBatch(
@@ -454,11 +455,11 @@ describe('GUnits-2', function () {
                         user10.address,
                     ])
             ).to.deep.equal([
-                depositAmount + firstPlaceAmount,
-                depositAmount + secondPlaceAmount,
-                depositAmount + thirdPlaceAmount,
-                depositAmount + fourthPlaceAmount,
-                depositAmount - lockAmount,
+                depositAmount - lockAmount + firstPlaceAmount, // 10 + 43.2 = 53.2
+                depositAmount - lockAmount + secondPlaceAmount, // 10 + 21.6 = 31.6
+                depositAmount - lockAmount + thirdPlaceAmount, // 10 + 14.4 = 24.4
+                depositAmount - lockAmount + fourthPlaceAmount, // 10 + 10.8 = 20.8
+                depositAmount - lockAmount, // Losers keep their 10 liquid
                 depositAmount - lockAmount,
                 depositAmount - lockAmount,
                 depositAmount - lockAmount,
@@ -562,7 +563,7 @@ describe('GUnits-2', function () {
             await chips.connect(gameServer).adminPayout(payouts, rakeFee);
 
             // Verify final state
-            expect(await chips.balanceOf(user1.address)).to.equal(depositAmount + winAmount);
+            expect(await chips.balanceOf(user1.address)).to.equal(depositAmount - entryFee + winAmount);
             expect(await chips.balanceOf(user2.address)).to.equal(depositAmount - entryFee);
             expect(await chips.getCollectedFees()).to.equal(rakeFee);
 


### PR DESCRIPTION
This pull request introduces several updates to the codebase, including new documentation for contract upgrades and verifications, enhancements to network configuration, improvements to contract definitions, and modifications to the `GUnits` contract and its associated tests. The changes aim to improve functionality, align configurations with best practices, and fix potential issues in the contract logic.

### Documentation Updates:
* Added sections in `README.md` explaining how to upgrade an upgradeable contract using a custom task and how to verify a custom interface.

### Network Configuration Enhancements:
* Updated `constants/network.ts` to include `ALCHEMY_API_KEY` from environment variables and replaced static RPC URLs for Arbitrum networks with dynamic URLs using the Alchemy API. [[1]](diffhunk://#diff-47a617e3c5e18f657a52a1a66ad8254b9e296266088b1124d902452b091c94a4L5-R5) [[2]](diffhunk://#diff-47a617e3c5e18f657a52a1a66ad8254b9e296266088b1124d902452b091c94a4L139-R140)

### Contract Definition Improvements:
* Refactored `constants/upgrades/index.ts` to use strongly-typed enums (`CONTRACT_TYPE`, `NETWORK_TYPE`, `NetworkName`, and `TENANT`) for better maintainability and clarity. Added a new configuration for the `GUnits` contract on the `ArbitrumOne` mainnet. [[1]](diffhunk://#diff-0fd07b6ad0725f8250aaa5fc4c5ef297f44aac98c7f1dfe52c6a9d75e4782fb1R5-R8) [[2]](diffhunk://#diff-0fd07b6ad0725f8250aaa5fc4c5ef297f44aac98c7f1dfe52c6a9d75e4782fb1L19-R47)

### `GUnits` Contract Logic Fixes:
* Moved the `decimals` variable in `GUnits.sol` to align with other state variables, ensuring better organization.
* Fixed the `_mintGUnits` logic to exclude the `buyInAmount` from the minting calculation, addressing a potential over-minting issue.

### Test Updates for `GUnits`:
* Updated test cases in `test/gunits.lock.test.ts` to reflect the corrected `_mintGUnits` logic. Adjusted expected balances and comments for clarity and accuracy. [[1]](diffhunk://#diff-e2cda2e37f1212fe86b3e26b46880cc1e22cdc74165c7fb49f7af05a4528319eL308-R312) [[2]](diffhunk://#diff-e2cda2e37f1212fe86b3e26b46880cc1e22cdc74165c7fb49f7af05a4528319eL457-R462) [[3]](diffhunk://#diff-e2cda2e37f1212fe86b3e26b46880cc1e22cdc74165c7fb49f7af05a4528319eL565-R566)